### PR TITLE
Don't show virtual size bytes on transaction view, when value not present

### DIFF
--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -6,7 +6,7 @@ block headContent
 		.field {
 			word-wrap: break-word;
 		}
-		
+
 
 block content
 	h1(class="h2") Transaction
@@ -56,7 +56,7 @@ block content
 						else
 							span N/A
 							span(class="text-muted")  (unconfirmed)
-				
+
 				tr
 					th(class="table-active properties-header") Timestamp
 					if (result.getrawtransaction.time)
@@ -64,41 +64,41 @@ block content
 					else
 						td(class="monospace") N/A
 							span(class="text-muted")  (unconfirmed)
-				
+
 				//tr
 				//	th(class="table-active properties-header") Transaction ID
 				//	td #{txid}
-				
+
 				tr
 					th(class="table-active properties-header") Version
 					td(class="monospace") #{result.getrawtransaction.version}
-				
+
 				tr
 					th(class="table-active properties-header") Size
 					td(class="monospace")
 						span #{result.getrawtransaction.size.toLocaleString()} bytes
-						if (result.getrawtransaction.vsize != result.getrawtransaction.size)
+						if (result.getrawtransaction.vsize && result.getrawtransaction.vsize != result.getrawtransaction.size)
 							span  (
 							a(href="https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Transaction_size_calculations") virtual size
 							span : #{result.getrawtransaction.vsize.toLocaleString()} bytes)
-				
+
 				if (result.getrawtransaction.locktime > 0)
 					tr
 						th(class="table-active properties-header")
 							span Locktime
 						td(class="monospace")
 							if (result.getrawtransaction.locktime < 500000000)
-								span Spendable in block 
+								span Spendable in block
 								a(href=("/block-height/" + result.getrawtransaction.locktime)) #{result.getrawtransaction.locktime}
 								span  or later - (
 								a(href="https://bitcoin.org/en/developer-guide#locktime-and-sequence-number", title="Locktime documentation")
-									span docs 
+									span docs
 									i(class="fa fa-external-link")
 								span )
 							else
 								span Spendable after #{moment.utc(new Date(result.getrawtransaction.locktime * 1000)).format("Y-MM-DD HH:mm:ss")} (utc) - (
 								a(href="https://bitcoin.org/en/developer-guide#locktime-and-sequence-number", title="Locktime documentation")
-									span docs 
+									span docs
 									i(class="fa fa-external-link")
 								span )
 
@@ -143,7 +143,7 @@ block content
 					div(class="row")
 						div(class="col-md-6")
 							h2(class="h5 mb-0") Input (#{result.getrawtransaction.vin.length.toLocaleString()})
-						div(class="col-md-6") 
+						div(class="col-md-6")
 							h2(class="h5 mb-0") Output (#{result.getrawtransaction.vout.length.toLocaleString()})
 				div(class="card-body")
 					div(class="row")
@@ -156,7 +156,7 @@ block content
 											th Input
 											th Amount
 									tbody
-									
+
 									if (result.getrawtransaction.vin[0].coinbase)
 										tr
 											th 1
@@ -178,7 +178,7 @@ block content
 													if (vout.scriptPubKey && vout.scriptPubKey.addresses)
 														span(class="monospace") #{vout.scriptPubKey.addresses[0]}
 														br
-														span(class="monospace text-muted") via tx 
+														span(class="monospace text-muted") via tx
 														a(href=("/tx/" + txInput.txid + "#output-" + result.getrawtransaction.vin[txInputIndex].vout), class="monospace") #{txInput.txid.substring(0, 14)}..., Output ##{result.getrawtransaction.vin[txInputIndex].vout + 1}
 												td
 													if (vout.value)
@@ -189,7 +189,7 @@ block content
 										td
 										td
 											strong(class="monospace") Σ #{totalInputValue}
-								
+
 
 						div(class="col-md-6")
 							table(class="table mb-0")
@@ -210,11 +210,11 @@ block content
 															span(class="monospace") #{vout.scriptPubKey.addresses[0]}
 
 													else if (vout.scriptPubKey.hex && vout.scriptPubKey.hex.startsWith('6a24aa21a9ed'))
-														span(class="monospace") Segregated Witness committment - 
+														span(class="monospace") Segregated Witness committment -
 														a(href="https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure") docs
 															i(class="fa fa-external-link")
 													else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
-														span(class="monospace") OP_RETURN: 
+														span(class="monospace") OP_RETURN:
 														span(class="monospace text-muted") #{utils.hex2ascii(vout.scriptPubKey.asm.substring("OP_RETURN ".length))}
 											td
 												span(class="monospace") Σ #{vout.value}
@@ -272,4 +272,4 @@ block content
 
 			//pre #{JSON.stringify(result.txInputs, null, 4)}
 
-	
+


### PR DESCRIPTION
The Transactions page errors when when  `result.getrawtransaction.vsize` is not present.  This fix add a check to only show virtual size when there is one. 

![image](https://user-images.githubusercontent.com/237220/43831175-2cdf7ab2-9afb-11e8-90b4-114c759b13de.png)